### PR TITLE
feature: some examples how to include resilience

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,23 +23,23 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - name: CDS samples - Install dependencies and build package
+      - name: CDS Samples - Install Dependencies and Build Package
         run:  |
          cd samples/cds-sample-application
           npm install
           npm run ci-build
-      - name: CDS samples - e2e Tests
+      - name: CDS Samples - Tests
         run:  |
          cd samples/cds-sample-application
-         npm run test:e2e
-      - name: Resilience examples - Install dependencies and build package
-          run:  |
-           cd samples/resilience-examples
-            npm install
-      - name: Resilience examples - Tests
+          npm run test:e2e
+      - name: Resilience Examples - Install Dependencies
         run:  |
          cd samples/resilience-examples
-         npm run test
+          npm install
+      - name: Resilience Examples - Tests
+        run:  |
+         cd samples/resilience-examples
+          npm run test
 
 
   dependabot:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,15 +23,25 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install dependencies and build package
+      - name: CDS samples - Install dependencies and build package
         run:  |
          cd samples/cds-sample-application
           npm install
           npm run ci-build
-      - name: e2e Tests
+      - name: CDS samples - e2e Tests
         run:  |
          cd samples/cds-sample-application
          npm run test:e2e
+      - name: Resilience examples - Install dependencies and build package
+          run:  |
+           cd samples/resilience-examples
+            npm install
+      - name: Resilience examples - Tests
+        run:  |
+         cd samples/resilience-examples
+         npm run test
+
+
   dependabot:
       needs: tests
       runs-on: ubuntu-latest

--- a/samples/resilience-examples/.eslintrc.js
+++ b/samples/resilience-examples/.eslintrc.js
@@ -1,0 +1,17 @@
+module.exports = {
+  env: { node: true, jest: true },
+  extends: ['@sap-cloud-sdk'],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: {
+      extends: 'tsconfig.json',
+      include: ['**/*.ts'],
+      exclude: []
+    },
+    sourceType: 'module'
+  },
+  ignorePatterns: [],
+  plugins: ['@typescript-eslint', 'header', 'import', 'prettier'],
+  rules: {},
+  overrides: []
+};

--- a/samples/resilience-examples/.prettierrc
+++ b/samples/resilience-examples/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json.schemastore.org/prettierrc",
+  "singleQuote": true,
+  "filepath": "*.ts",
+  "trailingComma": "none",
+  "arrowParens": "avoid",
+  "endOfLine": "lf"
+}

--- a/samples/resilience-examples/README.md
+++ b/samples/resilience-examples/README.md
@@ -1,0 +1,12 @@
+# SAP Cloud SDK for JS Resilience examples
+
+## Description
+
+This folder contains a few simples examples about resilience and the SDK.
+The examples are using well established libraries and are tested for you.
+They are meant as a blueprint to illustrate how resilience can be achieved, but there are many other ways out there which could be more fitting in your use case.
+
+- In `src/circuit-breaker.ts` the opossum circuit breaker is wrapped around a request.
+- In `src/retry.ts` the async-retry wrapper is used to retry failed requests.
+
+There is always a `*.spec.ts` file next to the examples which shows the actual execution and that the libraries show the expected behaviour.

--- a/samples/resilience-examples/package.json
+++ b/samples/resilience-examples/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "resilience-samples",
+  "version": "0.0.1",
+  "description": "SAP Cloud SDK for JS - Examples on Resilience",
+  "author": "Frank Essenberger",
+  "private": true,
+  "license": "UNLICENSED",
+  "scripts": {
+    "lint": "eslint \"src/**/*.ts\" --fix",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@sap/cloud-sdk-vdm-business-partner-service": "^2.0.0",
+    "@sap-cloud-sdk/util": "^2.0.0",
+    "@types/opossum": "^6.2.0",
+    "opossum": "^6.3.0",
+    "@types/async-retry": "^1.4.3",
+    "async-retry": "^1.3.3"
+  },
+  "devDependencies": {
+    "nock": "^13.2.4",
+    "@sap-cloud-sdk/test-util": "^2.0.0",
+    "@sap-cloud-sdk/eslint-config": "^2.0.0",
+    "@typescript-eslint/eslint-plugin": "^4.15.1",
+    "@typescript-eslint/parser": "^4.15.1",
+    "@types/jest": "^27.4.0",
+    "jest": "27.4.7",
+    "prettier": "2.5.1",
+    "eslint": "^7.32.0",
+    "eslint-plugin-header": "^3.1.1",
+    "eslint-plugin-import": "^2.20.2",
+    "eslint-plugin-prettier": "^3.1.3",
+    "eslint-plugin-unused-imports": "^1.1.0",
+    "ts-jest": "27.1.2",
+    "ts-loader": "9.2.6",
+    "ts-node": "10.4.0",
+    "typescript": "4.5.4"
+  },
+  "jest": {
+    "moduleFileExtensions": [
+      "js",
+      "json",
+      "ts"
+    ],
+    "rootDir": "src",
+    "testRegex": ".*\\.spec\\.ts$",
+    "transform": {
+      "^.+\\.(t|j)s$": "ts-jest"
+    },
+    "collectCoverageFrom": [
+      "**/*.(t|j)s"
+    ],
+    "coverageDirectory": "../coverage",
+    "testEnvironment": "node"
+  }
+}

--- a/samples/resilience-examples/package.json
+++ b/samples/resilience-examples/package.json
@@ -6,7 +6,8 @@
   "private": true,
   "license": "UNLICENSED",
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" --fix",
+    "lint": "eslint \"src/**/*.ts\" && yarn prettier .",
+    "lint:fix": "eslint \"src/**/*.ts\" --fix && yarn prettier . -w",
     "test": "jest"
   },
   "dependencies": {

--- a/samples/resilience-examples/src/business-partner-request.ts
+++ b/samples/resilience-examples/src/business-partner-request.ts
@@ -1,0 +1,15 @@
+import {
+  BusinessPartner,
+  businessPartnerService
+} from '@sap/cloud-sdk-vdm-business-partner-service';
+import { destinationName } from './test-util';
+
+export async function getAllBusinessPartner(
+  filterTop: number
+): Promise<BusinessPartner[]> {
+  return businessPartnerService()
+    .businessPartnerApi.requestBuilder()
+    .getAll()
+    .top(filterTop)
+    .execute({ destinationName });
+}

--- a/samples/resilience-examples/src/circuit-breaker.spec.ts
+++ b/samples/resilience-examples/src/circuit-breaker.spec.ts
@@ -1,0 +1,44 @@
+import { unmockAllTestDestinations } from '@sap-cloud-sdk/test-util';
+import nock from 'nock';
+import { createLogger } from '@sap-cloud-sdk/util';
+import { getAllBusinessPartnerWithCircuitBreaker } from './circuit-breaker';
+import { mockDestination, mockGetAllRequest } from './test-util';
+
+describe('circuit-breaker',()=>{
+    const numberWorkingRequests = [1,2,3,4,5];
+
+    const logger = createLogger('circuit-breaker');
+
+    beforeAll(()=>{
+        mockDestination();
+    });
+
+    beforeEach(()=>{
+        mockGetAllRequest(numberWorkingRequests.length);
+    });
+
+    afterEach(()=>{
+       nock.cleanAll();
+    });
+
+    afterAll(()=>{
+        unmockAllTestDestinations();
+    });
+
+    it('does not open the cuircuit breaker for no failed requests.',async ()=>{
+        const spy = jest.spyOn(logger,'warn');
+        await  Promise.all(numberWorkingRequests.map(()=>getAllBusinessPartnerWithCircuitBreaker(1)));
+        expect(spy).toHaveBeenCalledTimes(0);
+    });
+
+    it('opens the cuircuit after a few failed requests',async ()=>{
+        const spy = jest.spyOn(logger,'warn');
+
+        // The circuit breaker was configured to have 80% failure threshold. So 1 / 6 requests failing is enough to open the circuit
+        await  Promise.all([...numberWorkingRequests,6].map(()=>getAllBusinessPartnerWithCircuitBreaker(1)));
+        expect(spy).toHaveBeenCalledWith('Request failed to many times. Circuit breaker is open.');
+
+        // Circuit breaker is now open and the request is not executed.
+        await expect(getAllBusinessPartnerWithCircuitBreaker(1)).resolves.not.toThrow();
+    });
+});

--- a/samples/resilience-examples/src/circuit-breaker.spec.ts
+++ b/samples/resilience-examples/src/circuit-breaker.spec.ts
@@ -25,7 +25,7 @@ describe('circuit-breaker', () => {
     unmockAllTestDestinations();
   });
 
-  it('does not open the cuircuit breaker for no failed requests.', async () => {
+  it('does not open the circuit breaker for no failed requests.', async () => {
     const spy = jest.spyOn(logger, 'warn');
     await Promise.all(
       numberWorkingRequests.map(() =>

--- a/samples/resilience-examples/src/circuit-breaker.spec.ts
+++ b/samples/resilience-examples/src/circuit-breaker.spec.ts
@@ -4,41 +4,53 @@ import { createLogger } from '@sap-cloud-sdk/util';
 import { getAllBusinessPartnerWithCircuitBreaker } from './circuit-breaker';
 import { mockDestination, mockGetAllRequest } from './test-util';
 
-describe('circuit-breaker',()=>{
-    const numberWorkingRequests = [1,2,3,4,5];
+describe('circuit-breaker', () => {
+  const numberWorkingRequests = [1, 2, 3, 4, 5];
 
-    const logger = createLogger('circuit-breaker');
+  const logger = createLogger('circuit-breaker');
 
-    beforeAll(()=>{
-        mockDestination();
-    });
+  beforeAll(() => {
+    mockDestination();
+  });
 
-    beforeEach(()=>{
-        mockGetAllRequest(numberWorkingRequests.length);
-    });
+  beforeEach(() => {
+    mockGetAllRequest(numberWorkingRequests.length);
+  });
 
-    afterEach(()=>{
-       nock.cleanAll();
-    });
+  afterEach(() => {
+    nock.cleanAll();
+  });
 
-    afterAll(()=>{
-        unmockAllTestDestinations();
-    });
+  afterAll(() => {
+    unmockAllTestDestinations();
+  });
 
-    it('does not open the cuircuit breaker for no failed requests.',async ()=>{
-        const spy = jest.spyOn(logger,'warn');
-        await  Promise.all(numberWorkingRequests.map(()=>getAllBusinessPartnerWithCircuitBreaker(1)));
-        expect(spy).toHaveBeenCalledTimes(0);
-    });
+  it('does not open the cuircuit breaker for no failed requests.', async () => {
+    const spy = jest.spyOn(logger, 'warn');
+    await Promise.all(
+      numberWorkingRequests.map(() =>
+        getAllBusinessPartnerWithCircuitBreaker(1)
+      )
+    );
+    expect(spy).toHaveBeenCalledTimes(0);
+  });
 
-    it('opens the cuircuit after a few failed requests',async ()=>{
-        const spy = jest.spyOn(logger,'warn');
+  it('opens the cuircuit after a few failed requests', async () => {
+    const spy = jest.spyOn(logger, 'warn');
 
-        // The circuit breaker was configured to have 80% failure threshold. So 1 / 6 requests failing is enough to open the circuit
-        await  Promise.all([...numberWorkingRequests,6].map(()=>getAllBusinessPartnerWithCircuitBreaker(1)));
-        expect(spy).toHaveBeenCalledWith('Request failed to many times. Circuit breaker is open.');
+    // The circuit breaker was configured to have 80% failure threshold. So 1 / 6 requests failing is enough to open the circuit
+    await Promise.all(
+      [...numberWorkingRequests, 6].map(() =>
+        getAllBusinessPartnerWithCircuitBreaker(1)
+      )
+    );
+    expect(spy).toHaveBeenCalledWith(
+      'Request failed to many times. Circuit breaker is open.'
+    );
 
-        // Circuit breaker is now open and the request is not executed.
-        await expect(getAllBusinessPartnerWithCircuitBreaker(1)).resolves.not.toThrow();
-    });
+    // Circuit breaker is now open and the request is not executed.
+    await expect(
+      getAllBusinessPartnerWithCircuitBreaker(1)
+    ).resolves.not.toThrow();
+  });
 });

--- a/samples/resilience-examples/src/circuit-breaker.spec.ts
+++ b/samples/resilience-examples/src/circuit-breaker.spec.ts
@@ -35,7 +35,7 @@ describe('circuit-breaker', () => {
     expect(spy).toHaveBeenCalledTimes(0);
   });
 
-  it('opens the cuircuit after a few failed requests', async () => {
+  it('opens the circuit after a few failed requests', async () => {
     const spy = jest.spyOn(logger, 'warn');
 
     // The circuit breaker was configured to have 80% failure threshold. So 1 / 6 requests failing is enough to open the circuit

--- a/samples/resilience-examples/src/circuit-breaker.ts
+++ b/samples/resilience-examples/src/circuit-breaker.ts
@@ -1,7 +1,7 @@
 import { BusinessPartner } from '@sap/cloud-sdk-vdm-business-partner-service';
 import CircuitBreaker from 'opossum';
 import { createLogger } from '@sap-cloud-sdk/util';
-import { getAllBusinessPartner } from './test-util';
+import { getAllBusinessPartner } from './business-partner-request';
 
 const logger = createLogger('circuit-breaker');
 

--- a/samples/resilience-examples/src/circuit-breaker.ts
+++ b/samples/resilience-examples/src/circuit-breaker.ts
@@ -1,0 +1,27 @@
+import { BusinessPartner, businessPartnerService } from '@sap/cloud-sdk-vdm-business-partner-service';
+import CircuitBreaker from 'opossum';
+import { createLogger } from '@sap-cloud-sdk/util';
+import { destinationName } from './test-util';
+
+const logger = createLogger('circuit-breaker');
+
+function getAllBusinessPartner(top: number): Promise<BusinessPartner[]>{
+    return businessPartnerService().businessPartnerApi.requestBuilder().getAll().top(top).execute({ destinationName });
+}
+
+const breakerOptions = {
+    timeout: 3000,
+    errorThresholdPercentage: 80,
+    resetTimeout: 30000
+};
+
+// Create a new circuit breaker around the asyn method
+const breaker = new CircuitBreaker(getAllBusinessPartner,breakerOptions);
+
+// In the fallback you can put some logic to be executed if one system is not available.
+breaker.fallback(()=>logger.warn('Request failed to many times. Circuit breaker is open.'));
+
+// Execute the asyn method passing arguments if needed
+export function getAllBusinessPartnerWithCircuitBreaker(top: number): Promise<BusinessPartner[]>{
+    return breaker.fire(top);
+}

--- a/samples/resilience-examples/src/circuit-breaker.ts
+++ b/samples/resilience-examples/src/circuit-breaker.ts
@@ -1,27 +1,27 @@
-import { BusinessPartner, businessPartnerService } from '@sap/cloud-sdk-vdm-business-partner-service';
+import { BusinessPartner } from '@sap/cloud-sdk-vdm-business-partner-service';
 import CircuitBreaker from 'opossum';
 import { createLogger } from '@sap-cloud-sdk/util';
-import { destinationName } from './test-util';
+import { getAllBusinessPartner } from './test-util';
 
 const logger = createLogger('circuit-breaker');
 
-function getAllBusinessPartner(top: number): Promise<BusinessPartner[]>{
-    return businessPartnerService().businessPartnerApi.requestBuilder().getAll().top(top).execute({ destinationName });
-}
-
 const breakerOptions = {
-    timeout: 3000,
-    errorThresholdPercentage: 80,
-    resetTimeout: 30000
+  timeout: 3000,
+  errorThresholdPercentage: 80,
+  resetTimeout: 30000
 };
 
-// Create a new circuit breaker around the asyn method
-const breaker = new CircuitBreaker(getAllBusinessPartner,breakerOptions);
+// Create a new circuit breaker around the async method
+const breaker = new CircuitBreaker(getAllBusinessPartner, breakerOptions);
 
-// In the fallback you can put some logic to be executed if one system is not available.
-breaker.fallback(()=>logger.warn('Request failed to many times. Circuit breaker is open.'));
+// In the fallback you can put some logic to be executed if the breaker is open.
+breaker.fallback(() =>
+  logger.warn('Request failed to many times. Circuit breaker is open.')
+);
 
-// Execute the asyn method passing arguments if needed
-export function getAllBusinessPartnerWithCircuitBreaker(top: number): Promise<BusinessPartner[]>{
-    return breaker.fire(top);
+// Execute the async method passing arguments if needed
+export async function getAllBusinessPartnerWithCircuitBreaker(
+  top: number
+): Promise<BusinessPartner[]> {
+  return breaker.fire(top);
 }

--- a/samples/resilience-examples/src/retry.spec.ts
+++ b/samples/resilience-examples/src/retry.spec.ts
@@ -1,0 +1,37 @@
+import { unmockAllTestDestinations } from '@sap-cloud-sdk/test-util';
+import nock from 'nock';
+import { getAllBusinessPartners, getAllBusinessPartnerWithRetry } from './retry';
+import { destinationUrl, mockDestination, mockGetAllRequest } from './test-util';
+
+describe('retry',()=>{
+    beforeAll(()=>{
+       mockDestination();
+    });
+
+    beforeEach(()=>{
+    nock(destinationUrl)
+        .get(/.*/)
+        .times(2)
+        .reply(500);
+
+     mockGetAllRequest(1);
+    });
+
+    afterEach(()=>{
+        nock.cleanAll();
+    });
+
+    afterAll(()=>{
+        unmockAllTestDestinations();
+    });
+
+    it('fails without the retry.',async ()=>{
+        await expect(getAllBusinessPartners(1)()).rejects.toThrowError(`get request to ${destinationUrl}/sap/opu/odata/sap/API_BUSINESS_PARTNER failed!`);
+    });
+
+    it('resolves with retry',async ()=>{
+        // The mock will return after two failed attempts
+        const actual = await getAllBusinessPartnerWithRetry(1);
+        expect(actual.length).toBe(1);
+    });
+});

--- a/samples/resilience-examples/src/retry.spec.ts
+++ b/samples/resilience-examples/src/retry.spec.ts
@@ -1,37 +1,58 @@
 import { unmockAllTestDestinations } from '@sap-cloud-sdk/test-util';
 import nock from 'nock';
-import { getAllBusinessPartners, getAllBusinessPartnerWithRetry } from './retry';
-import { destinationUrl, mockDestination, mockGetAllRequest } from './test-util';
+import { createLogger } from '@sap-cloud-sdk/util';
+import { getAllBusinessPartnerWithRetry } from './retry';
+import {
+  destinationUrl,
+  getAllBusinessPartner,
+  mockDestination,
+  mockGetAllRequest
+} from './test-util';
 
-describe('retry',()=>{
-    beforeAll(()=>{
-       mockDestination();
-    });
+describe('retry', () => {
+  beforeAll(() => {
+    mockDestination();
+  });
 
-    beforeEach(()=>{
-    nock(destinationUrl)
-        .get(/.*/)
-        .times(2)
-        .reply(500);
+  beforeEach(() => {
+    nock(destinationUrl).get(/.*/).times(2).reply(500);
 
-     mockGetAllRequest(1);
-    });
+    mockGetAllRequest(1);
+  });
 
-    afterEach(()=>{
-        nock.cleanAll();
-    });
+  afterEach(() => {
+    nock.cleanAll();
+  });
 
-    afterAll(()=>{
-        unmockAllTestDestinations();
-    });
+  afterAll(() => {
+    unmockAllTestDestinations();
+  });
 
-    it('fails without the retry.',async ()=>{
-        await expect(getAllBusinessPartners(1)()).rejects.toThrowError(`get request to ${destinationUrl}/sap/opu/odata/sap/API_BUSINESS_PARTNER failed!`);
-    });
+  it('rejects without the retry.', async () => {
+    await expect(getAllBusinessPartner(1)).rejects.toThrowError(
+      `get request to ${destinationUrl}/sap/opu/odata/sap/API_BUSINESS_PARTNER failed!`
+    );
+  });
 
-    it('resolves with retry',async ()=>{
-        // The mock will return after two failed attempts
-        const actual = await getAllBusinessPartnerWithRetry(1);
-        expect(actual.length).toBe(1);
-    });
+  it('resolves with retry', async () => {
+    // The mock will return after two failed attempts
+    const actual = await getAllBusinessPartnerWithRetry(1);
+    expect(actual.length).toBe(1);
+  });
+
+  it('does not retry on 403 error', async () => {
+    nock.cleanAll();
+    nock(destinationUrl).get(/.*/).times(1).reply(401);
+
+    const logger = createLogger('retry');
+    const spy = jest.spyOn(logger, 'warn');
+    await expect(getAllBusinessPartnerWithRetry(1)).rejects.toThrowError(
+      `get request to ${destinationUrl}/sap/opu/odata/sap/API_BUSINESS_PARTNER failed!`
+    );
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(
+      'Request failed with status 401 - no retry necessary.'
+    );
+  });
 });

--- a/samples/resilience-examples/src/retry.spec.ts
+++ b/samples/resilience-examples/src/retry.spec.ts
@@ -4,10 +4,10 @@ import { createLogger } from '@sap-cloud-sdk/util';
 import { getAllBusinessPartnerWithRetry } from './retry';
 import {
   destinationUrl,
-  getAllBusinessPartner,
   mockDestination,
   mockGetAllRequest
 } from './test-util';
+import { getAllBusinessPartner } from './business-partner-request';
 
 describe('retry', () => {
   beforeAll(() => {

--- a/samples/resilience-examples/src/retry.ts
+++ b/samples/resilience-examples/src/retry.ts
@@ -1,0 +1,16 @@
+import { BusinessPartner, businessPartnerService } from '@sap/cloud-sdk-vdm-business-partner-service';
+import retry from 'async-retry';
+import { destinationName } from './test-util';
+
+export function getAllBusinessPartners(top: number): () => Promise<BusinessPartner[]>{
+    return ()=> businessPartnerService().businessPartnerApi.requestBuilder().getAll().top(top).execute({ destinationName });
+}
+
+const options = {
+    retries : 2,
+    minTimeout: 500
+};
+
+export function getAllBusinessPartnerWithRetry(top: number): Promise<BusinessPartner[]>{
+    return retry(getAllBusinessPartners(top),options);
+}

--- a/samples/resilience-examples/src/retry.ts
+++ b/samples/resilience-examples/src/retry.ts
@@ -1,7 +1,7 @@
 import { BusinessPartner } from '@sap/cloud-sdk-vdm-business-partner-service';
 import retry from 'async-retry';
 import { createLogger } from '@sap-cloud-sdk/util';
-import { getAllBusinessPartner } from './test-util';
+import { getAllBusinessPartner } from './business-partner-request';
 
 const logger = createLogger('retry');
 

--- a/samples/resilience-examples/src/test-util.ts
+++ b/samples/resilience-examples/src/test-util.ts
@@ -1,0 +1,22 @@
+import { setTestDestination } from '@sap-cloud-sdk/test-util';
+import nock from 'nock';
+
+export const destinationName = 'MyDestination';
+export const destinationUrl ='http://some.url.com';
+
+export function mockDestination(): void{
+    setTestDestination({ name: destinationName,url:destinationUrl });
+}
+
+export const sampleResponse = {
+    d: {
+        results: [{ BusinessPartner:1234 }]
+    }
+};
+
+export function mockGetAllRequest(times: number): void{
+    nock(destinationUrl)
+        .get(/.*/)
+        .times(times)
+        .reply(200,sampleResponse);
+}

--- a/samples/resilience-examples/src/test-util.ts
+++ b/samples/resilience-examples/src/test-util.ts
@@ -1,22 +1,33 @@
 import { setTestDestination } from '@sap-cloud-sdk/test-util';
 import nock from 'nock';
+import {
+  BusinessPartner,
+  businessPartnerService
+} from '@sap/cloud-sdk-vdm-business-partner-service';
 
 export const destinationName = 'MyDestination';
-export const destinationUrl ='http://some.url.com';
+export const destinationUrl = 'http://some.url.com';
 
-export function mockDestination(): void{
-    setTestDestination({ name: destinationName,url:destinationUrl });
+export function mockDestination(): void {
+  setTestDestination({ name: destinationName, url: destinationUrl });
 }
 
 export const sampleResponse = {
-    d: {
-        results: [{ BusinessPartner:1234 }]
-    }
+  d: {
+    results: [{ BusinessPartner: 1234 }]
+  }
 };
 
-export function mockGetAllRequest(times: number): void{
-    nock(destinationUrl)
-        .get(/.*/)
-        .times(times)
-        .reply(200,sampleResponse);
+export function mockGetAllRequest(times: number): void {
+  nock(destinationUrl).get(/.*/).times(times).reply(200, sampleResponse);
+}
+
+export async function getAllBusinessPartner(
+  top: number
+): Promise<BusinessPartner[]> {
+  return businessPartnerService()
+    .businessPartnerApi.requestBuilder()
+    .getAll()
+    .top(top)
+    .execute({ destinationName });
 }

--- a/samples/resilience-examples/src/test-util.ts
+++ b/samples/resilience-examples/src/test-util.ts
@@ -1,9 +1,5 @@
 import { setTestDestination } from '@sap-cloud-sdk/test-util';
 import nock from 'nock';
-import {
-  BusinessPartner,
-  businessPartnerService
-} from '@sap/cloud-sdk-vdm-business-partner-service';
 
 export const destinationName = 'MyDestination';
 export const destinationUrl = 'http://some.url.com';
@@ -20,14 +16,4 @@ export const sampleResponse = {
 
 export function mockGetAllRequest(times: number): void {
   nock(destinationUrl).get(/.*/).times(times).reply(200, sampleResponse);
-}
-
-export async function getAllBusinessPartner(
-  top: number
-): Promise<BusinessPartner[]> {
-  return businessPartnerService()
-    .businessPartnerApi.requestBuilder()
-    .getAll()
-    .top(top)
-    .execute({ destinationName });
 }

--- a/samples/resilience-examples/tsconfig.json
+++ b/samples/resilience-examples/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "target": "es2017",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./"
+  }
+}

--- a/samples/resilience-examples/tsconfig.json
+++ b/samples/resilience-examples/tsconfig.json
@@ -7,6 +7,7 @@
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
     "moduleResolution": "node",
+    "lib": ["ES2017"],
     "esModuleInterop": true,
     "target": "es2017",
     "sourceMap": true,


### PR DESCRIPTION
Added two examples for resilience: retry and circuit breaker. In order to execute it locally you must include a `.npmrc` with the internal nexus or wait until the 10th of feb until the 2.0 business partner VDM is availible.